### PR TITLE
switch to netstandard2.0 and remove unused using

### DIFF
--- a/src/Geohash.csproj
+++ b/src/Geohash.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>geohash-dotnet</PackageId>

--- a/src/Geohash.csproj
+++ b/src/Geohash.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageId>geohash-dotnet</PackageId>
     <Authors>Hans-Juergen Pavelka</Authors>
     <Company>Hans-Juergen Pavelka</Company>

--- a/src/PolygonHasher.cs
+++ b/src/PolygonHasher.cs
@@ -1,12 +1,6 @@
 ﻿using NetTopologySuite.Geometries;
-using NetTopologySuite.Index.Strtree;
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Diagnostics;
-using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace Geohash

--- a/src/PolygonHasher.cs
+++ b/src/PolygonHasher.cs
@@ -1,6 +1,8 @@
-﻿using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Geohash


### PR DESCRIPTION
Motivation: As a basic function and not dependent on a specific API, there is no need to specify a specific framework to enhance versatility

fixed #54 